### PR TITLE
Allows standard module importing to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-media-player",
   "version": "0.3.0",
   "description": "React media player.",
-  "main": "scripts/react-media-player.js",
+  "main": "lib/react-media-player.js",
   "scripts": {
     "build:lib": "babel src --out-dir lib",
     "build": "npm run build:lib && NODE_ENV=production webpack --config webpack.prod.config.js",


### PR DESCRIPTION
Sets main path in the package.json to use lib instead of scripts.

The following code:

```javascript
import { controls } from 'react-media-player';
```

Throws this error:
```shell
Module not found: Error: Cannot resolve module 'react-media-player' in
/Users/aaron/workspace/work/apps/disc/components/opinion/webpack/components
@ ./webpack/components/StimulusPlayer.js 13:24-53
```

I'm forced to use:

```javascript
import { controls } from 'react-media-player/lib/react-media-player.js';
```

It doesn't look like the project is has an `index.js` where you export the objects you want. 
It looks like the `main` directive in the `package.json` is wrong:

```json
"main": "scripts/react-media-player.js",
```

Changing the `package.json` to point to `lib/react-media-player.js` fixes the issue.