### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const { PlayPause, CurrentTime, Progress, SeekBar, Duration, MuteUnmute, Volume,
 
 class MediaPlayer extends Component {
   render() {
-    const { Player, media } = this.props
+    const { Player } = this.props
 
     return (
       <div className="media">


### PR DESCRIPTION
The media object is not available when using `withMediaPlayer`. Documentation leads to think it is available. 

Thanks for this great tool.