### PR TITLE
Use requestAnimationFrame for time updates in HTML5 vendor

### DIFF
--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -45,7 +45,9 @@ class HTML5 extends Component {
   }
 
   _handlePlay = () => {
-    this._timeUpdateId = requestAnimationFrame(this._handleTimeUpdate)
+    if (this._timeUpdateId !== null) {
+      this._timeUpdateId = requestAnimationFrame(this._handleTimeUpdate)
+    }
     this.props.onPlay(true)
   }
 

--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -4,6 +4,17 @@ import vendorPropTypes from './vendor-prop-types'
 class HTML5 extends Component {
   static propTypes = vendorPropTypes
 
+  _isMounted = false
+  _timeUpdateId = null
+  
+  componentDidMount() {
+    this._isMounted = true
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false
+  }
+  
   play() {
     this._player.play()
   }
@@ -34,10 +45,14 @@ class HTML5 extends Component {
   }
 
   _handlePlay = () => {
+    this._timeUpdateId = requestAnimationFrame(this._handleTimeUpdate)
     this.props.onPlay(true)
   }
 
   _handlePause = () => {
+    cancelAnimationFrame(this._timeUpdateId)
+    this._timeUpdateId = null
+    
     this.props.onPause(false)
   }
 
@@ -63,8 +78,14 @@ class HTML5 extends Component {
     this.props.onDuration(duration)
   }
 
-  _handleTimeUpdate = ({ target: { currentTime } }) => {
-    this.props.onTimeUpdate(currentTime)
+  _handleTimeUpdate = () => {
+    if (!this._isMounted) return
+
+    this.props.onTimeUpdate(this._player.currentTime || 0)
+
+    if (this._timeUpdateId) {
+      this._timeUpdateId = requestAnimationFrame(this._handleTimeUpdate)
+    }
   }
 
   _handleVolumeChange = ({ target: { volume, muted } }) => {
@@ -84,7 +105,6 @@ class HTML5 extends Component {
         onError={this._handleError}
         onProgress={this._handleProgress}
         onLoadedMetadata={this._handleDuration}
-        onTimeUpdate={this._handleTimeUpdate}
         onVolumeChange={this._handleVolumeChange}
       />
     )

--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -45,7 +45,7 @@ class HTML5 extends Component {
   }
 
   _handlePlay = () => {
-    if (this._timeUpdateId !== null) {
+    if (this._timeUpdateId === null) {
       this._timeUpdateId = requestAnimationFrame(this._handleTimeUpdate)
     }
     this.props.onPlay(true)

--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -52,7 +52,9 @@ class HTML5 extends Component {
   }
 
   _handlePause = () => {
-    cancelAnimationFrame(this._timeUpdateId)
+    if (this._timeUpdateId !== null) {
+      cancelAnimationFrame(this._timeUpdateId)
+    }
     this._timeUpdateId = null
     
     this.props.onPause(false)


### PR DESCRIPTION
The onTimeUpdate event from the browser is lagging. By using requestAnimationFrame (just like the Youtube player) the time updates are more frequent and smoother to render.

This pull request replaces the current event. For backwards compatibility, maybe an additional option or callback should be better? Another library (react-audio-player) uses the onListen event for a more frequent update.