### PR TITLE
fix(safari): fixes crash on Safari while buffering/loading

### DIFF
--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -20,9 +20,10 @@ class HTML5 extends Component {
     const { src, extraProps: { useAudioObject } } = nextProps
 
     if (useAudioObject) {
-      // update audio object source if necessary
+      // destroy and recreate audio object to clean up any browser state
       if (this.props.src !== src) {
-        this._player.src = src
+        this._destroyAudioObject()
+        this._createAudioObject(src)
       }
       // bind any new props to current audio object
       this._bindAudioObjectEvents(nextProps)


### PR DESCRIPTION
Safari intermittent crashes while loading/buffering audio. A workaround is to destroy and recreate the `Audio` object when `src` changes. For whatever reason this fixes the crash. I imagine it cleans up bad internal browser state.