### PR TITLE
fix(html5): guard against invalid state when setting current time during seeking

### DIFF
--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -54,7 +54,9 @@ class HTML5 extends Component {
   }
 
   seekTo(currentTime) {
-    this._player.currentTime = currentTime
+    if (this._player.readyState > 0) {
+      this._player.currentTime = currentTime
+    }
   }
 
   mute(muted) {


### PR DESCRIPTION
IE11 using the HTML 5 vendor during initial play:

![screen_shot_2016-09-20_at_4 48 03_pm](https://cloud.githubusercontent.com/assets/1541631/19354611/3aa413d2-911c-11e6-8aa9-3f33a5fe0ee2.png)

Fix found [here](http://stackoverflow.com/a/23616115)