### PR TITLE
fix(duration): fix for durations over an hour

### DIFF
--- a/src/utils/format-time.js
+++ b/src/utils/format-time.js
@@ -1,6 +1,6 @@
 export default function formatTime(current) {
   let h = Math.floor(current / 3600)
-  let m = Math.floor(current / 60)
+  let m = Math.floor((current - (h * 3600)) / 60)
   let s = Math.floor(current % 60)
 
   if (s < 10) {


### PR DESCRIPTION
```
formatTime(6725)
"1:112:05"
```

vs

```
formatTime(6725)
"1:52:05"
```