### PR TITLE
Update ALL imports of PropTypes

### DIFF
--- a/example/AudioPlayer.jsx
+++ b/example/AudioPlayer.jsx
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import ReactDOM, { findDOMNode } from 'react-dom'
+import PropTypes from 'prop-types'
 import { Media, Player, controls, utils } from '../src/react-media-player'
 import PlayPause from './PlayPause'
 import MuteUnmute from './MuteUnmute'

--- a/example/CirclePlayer.jsx
+++ b/example/CirclePlayer.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import CircleProgress from './CircleProgress'
 import { Media, Player } from '../src/react-media-player'
 

--- a/example/Fullscreen.jsx
+++ b/example/Fullscreen.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { withMediaProps } from '../src/react-media-player'
 
 class Fullscreen extends Component {

--- a/example/MediaPlayer.jsx
+++ b/example/MediaPlayer.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Media, Player, controls, utils } from '../src/react-media-player'
 import PlayPause from './PlayPause'
 import MuteUnmute from './MuteUnmute'

--- a/example/MuteUnmute.jsx
+++ b/example/MuteUnmute.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { withMediaProps } from '../src/react-media-player'
 import Transition from 'react-motion-ui-pack'
 

--- a/example/PlayPause.jsx
+++ b/example/PlayPause.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { withMediaProps } from '../src/react-media-player'
 import Transition from 'react-motion-ui-pack'
 

--- a/example/Repeat.jsx
+++ b/example/Repeat.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 class Repeat extends Component {
   render() {

--- a/example/VideoPlayer.jsx
+++ b/example/VideoPlayer.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Media, Player, withMediaProps, withKeyboardControls, controls } from '../src/react-media-player'
 import PlayPause from './PlayPause'
 import MuteUnmute from './MuteUnmute'

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes, createElement } from 'react'
+import React, { Component, createElement } from 'react'
 import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
 import MediaPlayer from './MediaPlayer'
 import VideoPlayer from './VideoPlayer'
 import AudioPlayer from './AudioPlayer'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.6.2",
   "description": "React media player.",
   "main": "lib/react-media-player.js",
-  "files": ["dist", "lib"],
+  "files": [
+    "dist",
+    "lib"
+  ],
   "scripts": {
     "build:lib": "babel src --out-dir lib",
     "build": "npm run build:lib && NODE_ENV=production webpack --config webpack.prod.config.js",

--- a/src/Media.jsx
+++ b/src/Media.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, Children } from 'react'
+import React, { Component, Children } from 'react'
+import PropTypes from 'prop-types';
 import ReactDOM, { findDOMNode } from 'react-dom'
 import contextTypes from './context-types'
 import requestFullscreen from './utils/request-fullscreen'

--- a/src/Player.jsx
+++ b/src/Player.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, createElement } from 'react'
+import React, { Component, createElement } from 'react'
+import PropTypes from 'prop-types'
 import contextTypes from './context-types'
 import getVendor from './utils/get-vendor'
 

--- a/src/controls/CurrentTime.jsx
+++ b/src/controls/CurrentTime.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 import formatTime from '../utils/format-time'
 

--- a/src/controls/Duration.jsx
+++ b/src/controls/Duration.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 import formatTime from '../utils/format-time'
 

--- a/src/controls/Fullscreen.jsx
+++ b/src/controls/Fullscreen.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
 class Fullscreen extends Component {

--- a/src/controls/MuteUnmute.jsx
+++ b/src/controls/MuteUnmute.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
 class MuteUnmute extends Component {

--- a/src/controls/PlayPause.jsx
+++ b/src/controls/PlayPause.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
 class PlayPause extends Component {

--- a/src/controls/Progress.jsx
+++ b/src/controls/Progress.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
 class Progress extends Component {

--- a/src/controls/SeekBar.jsx
+++ b/src/controls/SeekBar.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
 class SeekBar extends Component {

--- a/src/controls/Volume.jsx
+++ b/src/controls/Volume.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
 class Volume extends Component {

--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, createElement } from 'react'
+import React, { Component, createElement } from 'react'
+import PropTypes from 'prop-types'
 import { findDOMNode } from 'react-dom'
 import vendorPropTypes from './vendor-prop-types'
 


### PR DESCRIPTION
I updated to 0.62, and was still getting deprecation warnings in my console from MediaPlayer.
This changeset should address my exact scenario, and all other consumers.


> lowPriorityWarning.js:40 Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
> printWarning @ lowPriorityWarning.js:40
> lowPriorityWarning @ lowPriorityWarning.js:59
> get @ React.js:100
> ./node_modules/react-media-player/lib/Media.js @ Media.js:243
> __webpack_require__ @ bootstrap a1b5740…:659
> fn @ bootstrap a1b5740…:85
> ./node_modules/react-media-player/lib/react-media-player.js @ react-media-player.js:8
> __webpack_require__ @ bootstrap a1b5740…:659
> fn @ bootstrap a1b5740…:85
> ./src/components/main/messages/Messages/Chat/ChatMessage/Attachments/AudioPlayer.jsx @ AudioPlayer.css?40e8:26
> __webpack_require__ @ bootstrap a1b5740…:659
> fn @ bootstrap a1b5740…:85
