### PR TITLE
return promise from play function

### DIFF
--- a/src/vendors/HTML5.jsx
+++ b/src/vendors/HTML5.jsx
@@ -47,7 +47,7 @@ class HTML5 extends Component {
   }
 
   play() {
-    this._player.play()
+    return this._player.play()
   }
 
   pause() {


### PR DESCRIPTION
Autoplay in Safari 11 is blocked by default. Returning this promise allows us to grab the error so we can handle it.