### PR TITLE
Check if `document` is defined (SSR support)

### DIFF
--- a/src/utils/exit-fullscreen.js
+++ b/src/utils/exit-fullscreen.js
@@ -1,4 +1,8 @@
 export default (() => {
+  if (typeof document === 'undefined') {
+    return () => {}
+  }
+
   const names = [
     'exitFullscreen',
     'mozCancelFullScreen',

--- a/src/utils/request-fullscreen.js
+++ b/src/utils/request-fullscreen.js
@@ -1,4 +1,8 @@
 export default (() => {
+  if (typeof document === 'undefined') {
+    return () => {}
+  }
+
   const names = [
     'requestFullscreen',
     'mozRequestFullScreen',


### PR DESCRIPTION
Hi. First of all, thanks for the great and a pretty minimalistic lib. It is a rare case of a useful lib for React with just plain HOCs, foundation, to be able to construct something completely custom.

I've added type checks for `document` object in fullscreen functions make this library useful in SSR environments and toolkits like Gatsby, Next.js or Razzle.

It should fix #26, #17, #31

I've tested my PR locally: with these changes it works fine server-side.