### PR TITLE
Allow React 16 on peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "homepage": "https://github.com/souporserious/react-media-player",
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0",
-    "react-dom": "0.14.x || ^15.0.0"
+    "react": "0.14.x || ^15.0.0 || ^16.0.0",
+    "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
I guess it should be already compatible with React 16, right? Just trying to avoid the following warning:

![image](https://user-images.githubusercontent.com/1733354/38749781-3f630f38-3f29-11e8-8b54-928c263c06b2.png)
