### PR TITLE
formateTime was missing a 0 before minutes if it contains an hour

### DIFF
--- a/src/utils/format-time.js
+++ b/src/utils/format-time.js
@@ -8,6 +8,7 @@ export default function formatTime(current) {
   }
 
   if (h > 0) {
+    m = (m < 10) ? `0${m}` : m
     return h + ':' + m + ':' + s
   } else {
     return m + ':' + s


### PR DESCRIPTION
When looking at other media players online i.e. YouTube it seems the standard time format should contain two decimal minutes when crossing 1 hour. 

Example : "1:02:03" rather than "1:2:03"

Here's my fix