### PR TITLE
Export undecorated components as named exports

### DIFF
--- a/src/controls/CurrentTime.jsx
+++ b/src/controls/CurrentTime.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 import formatTime from '../utils/format-time'
 
-class CurrentTime extends Component {
+export class CurrentTime extends Component {
   shouldComponentUpdate({ media }) {
     return this.props.media.currentTime !== media.currentTime
   }

--- a/src/controls/Duration.jsx
+++ b/src/controls/Duration.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 import formatTime from '../utils/format-time'
 
-class Duration extends Component {
+export class Duration extends Component {
   shouldComponentUpdate({ media }) {
     return this.props.media.duration !== media.duration
   }

--- a/src/controls/Fullscreen.jsx
+++ b/src/controls/Fullscreen.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
-class Fullscreen extends Component {
+export class Fullscreen extends Component {
   shouldComponentUpdate({ media }) {
     return this.props.media.isFullscreen !== media.isFullscreen
   }

--- a/src/controls/MuteUnmute.jsx
+++ b/src/controls/MuteUnmute.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
-class MuteUnmute extends Component {
+export class MuteUnmute extends Component {
   shouldComponentUpdate({ media }) {
     return this.props.media.isMuted !== media.isMuted
   }

--- a/src/controls/PlayPause.jsx
+++ b/src/controls/PlayPause.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
-class PlayPause extends Component {
+export class PlayPause extends Component {
   shouldComponentUpdate({ media }) {
     return this.props.media.isPlaying !== media.isPlaying
   }

--- a/src/controls/Progress.jsx
+++ b/src/controls/Progress.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
-class Progress extends Component {
+export class Progress extends Component {
   shouldComponentUpdate({ media }) {
     return this.props.media.progress !== media.progress
   }

--- a/src/controls/SeekBar.jsx
+++ b/src/controls/SeekBar.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
-class SeekBar extends Component {
+export class SeekBar extends Component {
   _isPlayingOnMouseDown = false
   _onChangeUsed = false
 

--- a/src/controls/Volume.jsx
+++ b/src/controls/Volume.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import withMediaProps from '../decorators/with-media-props'
 
-class Volume extends Component {
+export class Volume extends Component {
   _onChangeUsed = false
 
   shouldComponentUpdate({ media }) {


### PR DESCRIPTION
Thanks for making this great library! I have a use case where I want to compose a UI out of the controls in this library, but I don't want to use the `Media` component. The way the components are written, the `this.props.media` can easily be used without the `media` `context`.

@souporserious I'm not sure if you agree with the style of named exports _and_ default exports in the same file, but this approach shouldn't break anything. I think allowing this can make the library much more powerful.